### PR TITLE
Add health check endpoints for monitoring

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,8 @@ from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 
+from footycollect.core.views import health_check, readiness_check
+
 urlpatterns = [
     path("", TemplateView.as_view(template_name="pages/home.html"), name="home"),
     path(
@@ -18,6 +20,9 @@ urlpatterns = [
         TemplateView.as_view(template_name="pages/about.html"),
         name="about",
     ),
+    # Health check endpoints
+    path("health/", health_check, name="health"),
+    path("ready/", readiness_check, name="ready"),
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     # User management

--- a/footycollect/core/tests/test_health_checks.py
+++ b/footycollect/core/tests/test_health_checks.py
@@ -1,0 +1,206 @@
+"""
+Tests for health check endpoints.
+"""
+
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+import pytest
+from django.db import DatabaseError
+from django.test import Client
+from django.urls import reverse
+
+HTTP_OK = HTTPStatus.OK
+HTTP_SERVICE_UNAVAILABLE = HTTPStatus.SERVICE_UNAVAILABLE
+
+
+@pytest.mark.django_db
+class TestHealthCheck:
+    """Test /health/ endpoint."""
+
+    def test_health_check_returns_200(self):
+        """Test that /health/ endpoint returns 200 when app is running."""
+        client = Client()
+        response = client.get(reverse("health"))
+
+        assert response.status_code == HTTP_OK
+        assert response["Content-Type"] == "application/json"
+        data = response.json()
+        assert data["status"] == "healthy"
+
+    def test_health_check_no_authentication_required(self):
+        """Test that /health/ endpoint does not require authentication."""
+        client = Client()
+        response = client.get(reverse("health"))
+
+        assert response.status_code == HTTP_OK
+
+    def test_health_check_lightweight(self):
+        """Test that /health/ endpoint is lightweight (no DB queries)."""
+        client = Client()
+        with patch("footycollect.core.views.connection") as mock_connection:
+            response = client.get(reverse("health"))
+
+            assert response.status_code == HTTP_OK
+            mock_connection.cursor.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestReadinessCheck:
+    """Test /ready/ endpoint."""
+
+    def test_readiness_check_all_services_ready(self):
+        """Test that /ready/ endpoint returns 200 when all services are ready."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_cache.set.return_value = True
+            mock_cache.get.return_value = "ok"
+
+            response = client.get(reverse("ready"))
+
+            assert response.status_code == HTTP_OK
+            assert response["Content-Type"] == "application/json"
+            data = response.json()
+            assert data["status"] == "ready"
+            assert data["checks"]["database"] is True
+            assert data["checks"]["redis"] is True
+
+    def test_readiness_check_database_unavailable(self):
+        """Test that /ready/ endpoint returns 503 when database is unavailable."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_connection.cursor.side_effect = DatabaseError("Connection failed")
+            mock_cache.set.return_value = True
+            mock_cache.get.return_value = "ok"
+
+            response = client.get(reverse("ready"))
+
+            assert response.status_code == HTTP_SERVICE_UNAVAILABLE
+            data = response.json()
+            assert data["status"] == "not ready"
+            assert data["checks"]["database"] is False
+            assert data["checks"]["redis"] is True
+
+    def test_readiness_check_redis_unavailable(self):
+        """Test that /ready/ endpoint returns 503 when Redis is unavailable."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_cache.set.side_effect = Exception("Redis connection failed")
+
+            response = client.get(reverse("ready"))
+
+            assert response.status_code == HTTP_SERVICE_UNAVAILABLE
+            data = response.json()
+            assert data["status"] == "not ready"
+            assert data["checks"]["database"] is True
+            assert data["checks"]["redis"] is False
+
+    def test_readiness_check_both_services_unavailable(self):
+        """Test that /ready/ endpoint returns 503 when both services are unavailable."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_connection.cursor.side_effect = DatabaseError("Connection failed")
+            mock_cache.set.side_effect = Exception("Redis connection failed")
+
+            response = client.get(reverse("ready"))
+
+            assert response.status_code == HTTP_SERVICE_UNAVAILABLE
+            data = response.json()
+            assert data["status"] == "not ready"
+            assert data["checks"]["database"] is False
+            assert data["checks"]["redis"] is False
+
+    def test_readiness_check_redis_not_configured(self):
+        """Test that /ready/ endpoint handles Redis not configured gracefully."""
+        client = Client()
+
+        with patch("footycollect.core.views.connection") as mock_connection:
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+
+            with patch("django.core.cache.cache") as mock_cache:
+                mock_cache.set.side_effect = ImportError("No module named 'django_redis'")
+
+                response = client.get(reverse("ready"))
+
+                assert response.status_code == HTTP_SERVICE_UNAVAILABLE
+                data = response.json()
+                assert data["status"] == "not ready"
+                assert data["checks"]["database"] is True
+                assert data["checks"]["redis"] is False
+
+    def test_readiness_check_no_authentication_required(self):
+        """Test that /ready/ endpoint does not require authentication."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_cache.set.return_value = True
+            mock_cache.get.return_value = "ok"
+
+            response = client.get(reverse("ready"))
+
+            assert response.status_code == HTTP_OK
+
+    def test_readiness_check_json_format(self):
+        """Test that /ready/ endpoint returns JSON format."""
+        client = Client()
+
+        with (
+            patch("footycollect.core.views.connection") as mock_connection,
+            patch(
+                "django.core.cache.cache",
+            ) as mock_cache,
+        ):
+            mock_cursor = Mock()
+            mock_cursor.fetchone.return_value = (1,)
+            mock_connection.cursor.return_value.__enter__.return_value = mock_cursor
+            mock_cache.set.return_value = True
+            mock_cache.get.return_value = "ok"
+
+            response = client.get(reverse("ready"))
+
+            assert response["Content-Type"] == "application/json"
+            data = response.json()
+            assert "status" in data
+            assert "checks" in data
+            assert "database" in data["checks"]
+            assert "redis" in data["checks"]

--- a/footycollect/core/views.py
+++ b/footycollect/core/views.py
@@ -1,1 +1,71 @@
-# Create your views here.
+"""
+Health check views for monitoring and deployment orchestration.
+"""
+
+import logging
+
+from django.db import connection
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+logger = logging.getLogger(__name__)
+
+
+@require_GET
+def health_check(request):
+    """
+    Basic health check endpoint.
+
+    Returns 200 if the application is running.
+    This endpoint is lightweight and does not check external services.
+    """
+    return JsonResponse({"status": "healthy"}, status=200)
+
+
+@require_GET
+def readiness_check(request):
+    """
+    Readiness check endpoint.
+
+    Checks database and Redis connectivity.
+    Returns 200 if all services are ready, 503 if any service is unavailable.
+    """
+    checks = {
+        "database": False,
+        "redis": False,
+    }
+
+    # Check database connectivity
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        checks["database"] = True
+    except Exception:
+        logger.exception("Database connectivity check failed")
+        checks["database"] = False
+
+    # Check Redis connectivity
+    try:
+        from django.core.cache import cache
+
+        cache.set("health_check", "ok", 1)
+        cache.get("health_check")
+        checks["redis"] = True
+    except ImportError:
+        logger.warning("Redis cache backend not configured")
+        checks["redis"] = False
+    except Exception:
+        logger.exception("Redis connectivity check failed")
+        checks["redis"] = False
+
+    # Determine overall status
+    all_ready = all(checks.values())
+    status_code = 200 if all_ready else 503
+
+    response_data = {
+        "status": "ready" if all_ready else "not ready",
+        "checks": checks,
+    }
+
+    return JsonResponse(response_data, status=status_code)


### PR DESCRIPTION
## Summary
Implements health check endpoints for monitoring and deployment orchestration.

## Changes
- ✅ Created /health/ endpoint - basic app health (lightweight, no DB queries)
- ✅ Created /ready/ endpoint - readiness check with DB and Redis connectivity
- ✅ Added routes to config/urls.py at root level
- ✅ Return appropriate HTTP status codes (200 for healthy/ready, 503 for not ready)
- ✅ JSON response format
- ✅ No authentication required
- ✅ Comprehensive test suite (10 tests, all passing)

## Endpoints
- `GET /health/` - Returns 200 if app is running
- `GET /ready/` - Returns 200 if all services ready, 503 if any unavailable

## Response Format
`/health/`:
```json
{"status": "healthy"}
```

`/ready/`:
```json
{
  "status": "ready",
  "checks": {
    "database": true,
    "redis": true
  }
}
```

## Testing
- ✅ All 10 tests passing
- ✅ Ruff checks passing
- ✅ Pre-commit hooks passing

## Related Issue
Fixes #147