### PR TITLE
Fix R2 storage: use custom domain for public URLs and reduce logging noise

### DIFF
--- a/footycollect/collection/templatetags/image_tags.py
+++ b/footycollect/collection/templatetags/image_tags.py
@@ -1,6 +1,3 @@
-# ruff: noqa: S308
-from pathlib import Path
-
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -15,9 +12,9 @@ def responsive_image(photo, css_class=""):
     avif_url = ""
     if photo.image_avif:
         try:
-            if Path(photo.image_avif.path).exists():
+            if photo.image_avif.storage.exists(photo.image_avif.name):
                 avif_url = photo.image_avif.url
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, NotImplementedError):
             pass
 
     if avif_url:
@@ -30,4 +27,4 @@ def responsive_image(photo, css_class=""):
     else:
         html = f'<img src="{original_url}" class="{css_class}" alt="{photo.caption}">'
 
-    return mark_safe(html)
+    return mark_safe(html)  # noqa: S308

--- a/footycollect/collection/views/item_views.py
+++ b/footycollect/collection/views/item_views.py
@@ -52,7 +52,6 @@ def demo_brand_view(request):
 
 def home(request):
     """Home view with animated jersey cards in background."""
-    from pathlib import Path
 
     from footycollect.collection.models import Jersey
 
@@ -86,10 +85,10 @@ def home(request):
             for photo in photos:
                 if photo.image:
                     try:
-                        if Path(photo.image.path).exists():
+                        if photo.image.storage.exists(photo.image.name):
                             jerseys_with_photos.append(jersey)
                             break
-                    except (ValueError, AttributeError):
+                    except (ValueError, AttributeError, NotImplementedError):
                         continue
 
         items = jerseys_with_photos


### PR DESCRIPTION
## Changes

- Fixed R2 storage configuration to use CLOUDFLARE_R2_CUSTOM_DOMAIN (public R2.dev URL) instead of private endpoint URL
- Configured AWS_S3_CUSTOM_DOMAIN so django-storages generates correct public URLs
- Reduced boto3/botocore logging noise in development (set to WARNING level)
- Fixed static files to be served locally in development (not from R2)

## Technical Details

- When CLOUDFLARE_R2_CUSTOM_DOMAIN is set, it's now properly used for AWS_S3_CUSTOM_DOMAIN
- This ensures photo URLs use the public R2.dev domain instead of the private endpoint
- Static files remain served locally in development for better performance
- Logging configuration reduces DEBUG spam from AWS SDK libraries